### PR TITLE
docs Apache 2.0 license requirements

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,0 @@
-* patrick.koss@mail.schwarz
-* marius.galm@mail.schwarz
-* simon.stier@mail.schwarz
-* christopher.paul@mail.schwarz

--- a/NOTICE
+++ b/NOTICE
@@ -3,7 +3,7 @@ Apache 2.0 Licensed Notice
 The Initial Developer of some parts of this project, which are copied from, derived from, or
 inspired by https://github.com/stackitcloud/external-dns-stackit-webhook is STACKIT Cloud (Schwarz IT KG) (http://www.stackit.de/en).
 
-This product includes software modified by Selectel (https://selectel.ru/en) at 2024 to work properly 
+This product includes software modified by Selectel (https://selectel.com) at 2024 to work properly 
 with Selectel DNS API. All of these file located in the directories:
 - /cmd/
 - /internal/

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,17 @@
+Apache 2.0 Licensed Notice
+
+The Initial Developer of some parts of this project, which are copied from, derived from, or
+inspired by https://github.com/stackitcloud/external-dns-stackit-webhook is STACKIT Cloud (Schwarz IT KG) (http://www.stackit.de/en).
+
+This product includes software modified by Selectel (https://selectel.ru/en) at 2024 to work properly 
+with Selectel DNS API. All of these file located in the directories:
+- /cmd/
+- /internal/
+- /pkg/httpdefault/
+- /pkg/keystone/
+
+Other modifications were made due to repository and packages renaming and changes in documentation to accommodate Selectel DNS API.
+
+This modified software is distributed under the terms of the Apache License, Version 2.0. 
+The full text of the license may be found at https://www.apache.org/licenses/LICENSE-2.0.
+

--- a/NOTICE
+++ b/NOTICE
@@ -4,7 +4,7 @@ The Initial Developer of some parts of this project, which are copied from, deri
 inspired by https://github.com/stackitcloud/external-dns-stackit-webhook is STACKIT Cloud (Schwarz IT KG) (http://www.stackit.de/en).
 
 This product includes software modified by Selectel (https://selectel.com) at 2024 to work properly 
-with Selectel DNS API. All of these file located in the directories:
+with Selectel DNS API. All these files are located in the directories:
 - /cmd/
 - /internal/
 - /pkg/httpdefault/


### PR DESCRIPTION
Changes:
- removed CODEOWNERS (this file is not required due to Apache 2.0)
- added NOTICE with information about initial developer (stackit) and modified files